### PR TITLE
Support new error response standard

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class PriceCheckQuerier {
           });
       })
       .then(({ queryResults, results }) => {
-        if (queryResults && Object.keys(queryResults).length > 0) {
+        if (queryResults && !queryResults.error) {
           return [new NexusItem(queryResults, `/${results.value[0].type}/${encodeURIComponent(results.value[0].name.replace(/\sPrime/ig, ''))}`)];
         }
         return [noResultAttachment];


### PR DESCRIPTION
Instead of returning `{}`, the Nexus-Stats API will return the following error format:
```json
{
  "error": "Something went wrong",
  "reason": "This is why"
}
```
This will become the standard error response format for all endpoints.